### PR TITLE
Stop using the `quoted_na` argument of `readr::read_csv()`

### DIFF
--- a/R/import_data.R
+++ b/R/import_data.R
@@ -55,7 +55,6 @@ import_mhealth_csv <- function(filepath) {
   }
 
   df <- readr::read_csv(file = filepath,
-                        quoted_na = TRUE,
                         col_types = coltypes)
   # convert factors back to characters
   col_classes <- sapply(1:ncols, function(i) {


### PR DESCRIPTION
The `quoted_na` argument will be removed from `readr::read_csv()` in its next release. It has been deprecated for over 4 years, since readr v2.0.0 (2021-07-20).

If it's important to use `quoted_na`, then instead of the change in this PR, you could explicitly use the first edition of readr in the docs linked. But note that the first edition itself may eventually be retired one day, so if possible, I'd just update the code for current readr.

https://readr.tidyverse.org/reference/with_edition.html

This is part of a bigger effort to advance a bunch of deprecation processes that started 4+ years ago: <https://github.com/tidyverse/readr/issues/1600>. I released readr v2.1.6 on 2025-11-14 and have no immediate plans for another release. I just wanted to advance these deprecations right away, to give downstream dependencies plenty of time to adjust.

I am also sending an email to the maintainer listed in DESCRIPTION. 